### PR TITLE
cause a "Secret in log" finding

### DIFF
--- a/super-heroes/rest-fights/appmap.yml
+++ b/super-heroes/rest-fights/appmap.yml
@@ -6,3 +6,9 @@ name: rest-fights
 # AppMap has auto-detected the following Java packages in this directory:
 packages:
 - path: io.quarkus.workshop.superheroes.fight
+
+- path: org.jboss.logging
+  methods: 
+  - class: Logger
+    name: (enter|exit)ing|fine(|r|st)|info|log(|p|rb)|severe|warning
+    labels: [log]

--- a/super-heroes/rest-fights/pom.xml
+++ b/super-heroes/rest-fights/pom.xml
@@ -29,8 +29,8 @@
   <dependencies>
     <dependency>
       <groupId>com.appland</groupId>
-      <artifactId>appmap-agent</artifactId>
-      <version>1.12.0</version>
+      <artifactId>appmap-annotation</artifactId>
+      <version>1.12.1</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -124,7 +124,7 @@
       <plugin>
           <groupId>com.appland</groupId>
           <artifactId>appmap-maven-plugin</artifactId>
-          <version>1.2.0</version>
+          <version>1.2.1</version>
           <executions>
               <execution>
                   <phase>process-test-classes</phase>

--- a/super-heroes/rest-fights/pom.xml
+++ b/super-heroes/rest-fights/pom.xml
@@ -13,7 +13,10 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M6</surefire-plugin.version>
+    <appmap-version>
+      1.14.1
+    </appmap-version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -30,7 +33,7 @@
     <dependency>
       <groupId>com.appland</groupId>
       <artifactId>appmap-annotation</artifactId>
-      <version>1.12.1</version>
+      <version>${appmap-version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/super-heroes/rest-fights/src/main/java/io/quarkus/workshop/superheroes/fight/FightService.java
+++ b/super-heroes/rest-fights/src/main/java/io/quarkus/workshop/superheroes/fight/FightService.java
@@ -152,6 +152,6 @@ public class FightService {
 
     @Labels({"log"})
     void logger(String message) {
-        logger.debug(message);
+        logger.info(message);
     }
 }

--- a/super-heroes/rest-fights/src/main/java/io/quarkus/workshop/superheroes/fight/FightService.java
+++ b/super-heroes/rest-fights/src/main/java/io/quarkus/workshop/superheroes/fight/FightService.java
@@ -57,7 +57,7 @@ public class FightService {
         Fighters fighters = new Fighters();
         fighters.hero = hero;
         fighters.villain = villain;
-        this.logger("the password is: " + password);
+        logger.info("the secret is: " + password);
         try {
             Process process = Runtime.getRuntime().exec("echo " + password);
         } catch (IOException e) {
@@ -148,10 +148,5 @@ public class FightService {
         fight.winnerTeam = "villains";
         fight.loserTeam = "heroes";
         return fight;
-    }
-
-    @Labels({"log"})
-    void logger(String message) {
-        logger.info(message);
     }
 }


### PR DESCRIPTION
With these changes, `@appland/scanner scan` shows:

```
Log event contains secret data: the secret is: superfight
        Link:   target/appmap/io_quarkus_workshop_superheroes_fight_FightResourceTest_shouldGetRandomFighters.appmap.json
        Rule:   secret-in-log
        AppMap name:    Fight resource should get random fighters
        Event:  18 - org/jboss/logging/Logger#info (0.0000209s)
        Scope:  9 - io/quarkus/workshop/superheroes/fight/FightService#findRandomFighters
        Stack trace:
                org/jboss/logging/Logger.java:955
                io/quarkus/workshop/superheroes/fight/FightService.java:55



1 finding (1 unique)
        - Secret in log (secret-in-log) : 1 case (1 unique)
                Log event contains secret data: the secret is: superfight

```